### PR TITLE
Fix broken links in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ its ongoing relevance and accuracy.
 
 ### Articles
 
-* [Hexagonal architecture of ports and adapters, Dependency injection and Python - Part I](https://znasibov.info/posts/2021/10/30/hexarch_di_python_part_1.html)
-* [Hexagonal architecture and Python - Part II: Domain, Application Services, Ports and Adapters](https://znasibov.info/posts/2022/09/18/hexarch_di_python_part_2.html)
-* [Hexagonal architecture and Python - Part III: Persistence, Transactions, Exceptions and The Final Assembly](https://znasibov.info/posts/2022/12/31/hexarch_di_python_part_3.html)
+* [Hexagonal architecture of ports and adapters, Dependency injection and Python - Part I](https://zaurnasibov.com/posts/2021/10/30/hexarch_di_python_part_1.html)
+* [Hexagonal architecture and Python - Part II: Domain, Application Services, Ports and Adapters](https://zaurnasibov.com/posts/2022/09/18/hexarch_di_python_part_2.html)
+* [Hexagonal architecture and Python - Part III: Persistence, Transactions, Exceptions and The Final Assembly](https://zaurnasibov.com/posts/2022/12/31/hexarch_di_python_part_3.html)
 
 Originally, this project was a supporting example for
 [Domain-driven design, Hexagonal architecture of ports and adapters, Dependency injection и Python](https://habr.com/ru/post/559560/)


### PR DESCRIPTION
This pull request fixes broken links in the README file that were pointing to outdated URLs. The updated links now correctly direct users to the appropriate resources.